### PR TITLE
Remove CNAME and SRV records

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,10 @@ If `minimum SRV records` is specified in the configuration, the plugin will wait
 until it has at least that many SRV records before responding with any of them.
 `minimum SRV records` defaults to `3`.
 
-~~~ corefile
-example.com {
-    mdns example.com 2
-}
-~~~
-
-This would mean that at least two SRV records of a given type would need to be
-present for any SRV records to be returned. If only one record is found, any
-requests for that type of SRV record would receive no results.
+NOTE: Support for SRV records has been removed, so the `minimum SRV records`
+option is now ignored. The parameter is left for backward compatibility with
+existing configurations, but its value will have no effect on the behavior
+of the plugin.
 
 If `filter text` is specified in the configuration, the plugin will ignore any
 mDNS records that do not include the specified text in the service name. This

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -49,9 +49,8 @@ func TestAddARecord(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		hosts := tc.hosts
-		srvHosts := make(map[string][]*zeroconf.ServiceEntry)
 		mutex := sync.RWMutex{}
-		m := MDNS{nil, tc.domain, 0, "", "", &mutex, &hosts, &srvHosts}
+		m := MDNS{nil, tc.domain, "", "", &mutex, &hosts}
 		msg := new(dns.Msg)
 		reply := new(dns.Msg)
 		msg.SetReply(reply)

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -50,9 +50,8 @@ func TestAddARecord(t *testing.T) {
 	for _, tc := range testCases {
 		hosts := tc.hosts
 		srvHosts := make(map[string][]*zeroconf.ServiceEntry)
-		cnames := make(map[string]string)
 		mutex := sync.RWMutex{}
-		m := MDNS{nil, tc.domain, 0, "", "", &mutex, &hosts, &srvHosts, &cnames}
+		m := MDNS{nil, tc.domain, 0, "", "", &mutex, &hosts, &srvHosts}
 		msg := new(dns.Msg)
 		reply := new(dns.Msg)
 		msg.SetReply(reply)

--- a/setup.go
+++ b/setup.go
@@ -52,9 +52,8 @@ func setup(c *caddy.Controller) error {
 	// pointers so all copies of the plugin point at the same maps.
 	mdnsHosts := make(map[string]*zeroconf.ServiceEntry)
 	srvHosts := make(map[string][]*zeroconf.ServiceEntry)
-	cnames := make(map[string]string)
 	mutex := sync.RWMutex{}
-	m := MDNS{Domain: strings.TrimSuffix(domain, "."), minSRV: minSRV, filter: filter, bindAddress: bindAddress, mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts, cnames: &cnames}
+	m := MDNS{Domain: strings.TrimSuffix(domain, "."), minSRV: minSRV, filter: filter, bindAddress: bindAddress, mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts}
 
 	c.OnStartup(func() error {
 		go browseLoop(&m)

--- a/setup.go
+++ b/setup.go
@@ -26,17 +26,17 @@ func setup(c *caddy.Controller) error {
 	c.Next()
 	c.NextArg()
 	domain := c.Val()
-	minSRV := 3
 	// Note that a filter of "" will match everything
 	filter := ""
 	bindAddress := ""
+	// minSRV is no longer used, but we can't just remove it without
+	// breaking existing configs.
 	if c.NextArg() {
-		val, err := strconv.Atoi(c.Val())
+		_, err := strconv.Atoi(c.Val())
 		if err != nil {
 			text := fmt.Sprintf("Invalid minSRV: %s", err)
 			return plugin.Error("mdns", errors.New(text))
 		}
-		minSRV = val
 	}
 	if c.NextArg() {
 		filter = c.Val()
@@ -51,9 +51,8 @@ func setup(c *caddy.Controller) error {
 	// Because the plugin interface uses a value receiver, we need to make these
 	// pointers so all copies of the plugin point at the same maps.
 	mdnsHosts := make(map[string]*zeroconf.ServiceEntry)
-	srvHosts := make(map[string][]*zeroconf.ServiceEntry)
 	mutex := sync.RWMutex{}
-	m := MDNS{Domain: strings.TrimSuffix(domain, "."), minSRV: minSRV, filter: filter, bindAddress: bindAddress, mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts}
+	m := MDNS{Domain: strings.TrimSuffix(domain, "."), filter: filter, bindAddress: bindAddress, mutex: &mutex, mdnsHosts: &mdnsHosts}
 
 	c.OnStartup(func() error {
 		go browseLoop(&m)


### PR DESCRIPTION
It turns out we can do this with an A record in mdns, so we don't
need the hard-coded CNAME generation in the plugin.