### PR TITLE
Add Makefile for ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.DEFAULT_GOAL:=help
+
+.PHONY: fmt
+fmt: ## Run go fmt against code
+	go fmt *.go
+
+.PHONY: vet
+vet: ## Run go vet against code
+	go vet *.go


### PR DESCRIPTION
Like mdns-publisher, we want to have a makefile in this repo that
we can use to run things like go fmt and go vet.

Note that at this time go vet is failing for me on this repo. I
don't think it's a valid complaint, but I'm not sure how to fix it
either.