### PR TITLE
Check that go fmt has no changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: fmt
 fmt: ## Run go fmt against code
 	go fmt *.go
+	git diff --exit-code
 
 .PHONY: vet
 vet: ## Run go vet against code

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/miekg/dns v1.1.14
 	golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b
 )
+
+go 1.13


### PR DESCRIPTION
Previously the makefile only ran go fmt but didn't verify whether it
had to make changes. This adds a git diff --exit-code call to the
target so it will fail if the code was not formatted properly.