### PR TITLE
Check only for first entry in answer list

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -42,12 +42,12 @@ func (m MDNS) AddARecord(msg *dns.Msg, state *request.Request, hosts map[string]
 	// provides common code for doing so.
 	answerEntry, present := hosts[name]
 	if present {
-		if answerEntry.AddrIPv4 != nil {
+		if answerEntry.AddrIPv4[0] != nil {
 			aheader := dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}
 			// TODO: Support multiple addresses
 			msg.Answer = append(msg.Answer, &dns.A{Hdr: aheader, A: answerEntry.AddrIPv4[0]})
 		}
-		if answerEntry.AddrIPv6 != nil {
+		if answerEntry.AddrIPv6[0] != nil {
 			aaaaheader := dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60}
 			msg.Answer = append(msg.Answer, &dns.AAAA{Hdr: aaaaheader, AAAA: answerEntry.AddrIPv6[0]})
 		}


### PR DESCRIPTION
The AddrIPv4 and AddrIPv6 in answerEntry are slices. The code incorrectly
checked for those entries to be nil, and not the [0] that is later
appended. This had the effect of adding a nil entry to the response,
which rendered it invalid.

Fixes: #42