### PR TITLE
Stop overwriting the SRV record with etcd CNAME

### DIFF
--- a/hack/build-coredns.sh
+++ b/hack/build-coredns.sh
@@ -13,6 +13,8 @@
 
 set -ex -o pipefail
 
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
+
 export GOPATH="${1:-$(mktemp -d)}"
 if [ -z "${1:-}" ]
 then
@@ -33,5 +35,10 @@ git checkout ${COREDNS_BRANCH}
 # Make coredns use our local source
 rm vendor/github.com/openshift/coredns-mdns/*
 cp $source_dir/*.go vendor/github.com/openshift/coredns-mdns
-GO111MODULE=on GOFLAGS=-mod=vendor go build -o coredns .
-cp coredns "$source_dir"
+if [ -z "$CONTAINER_IMAGE" ]
+then
+    GO111MODULE=on GOFLAGS=-mod=vendor go build -o coredns .
+    cp coredns "$source_dir"
+else
+    podman build -t "$CONTAINER_IMAGE" -f Dockerfile.openshift .
+fi

--- a/hack/build-coredns.sh
+++ b/hack/build-coredns.sh
@@ -33,8 +33,8 @@ fi
 cd coredns
 git checkout ${COREDNS_BRANCH}
 # Make coredns use our local source
-rm vendor/github.com/openshift/coredns-mdns/*
-cp $source_dir/*.go vendor/github.com/openshift/coredns-mdns
+GO111MODULE=on go mod edit -replace github.com/openshift/coredns-mdns=$source_dir
+GO111MODULE=on go mod vendor
 if [ -z "$CONTAINER_IMAGE" ]
 then
     GO111MODULE=on GOFLAGS=-mod=vendor go build -o coredns .

--- a/hack/build-coredns.sh
+++ b/hack/build-coredns.sh
@@ -7,10 +7,6 @@
 # coredns. If not provided, a temporary directory will be created
 # and deleted after the build finishes. If it is provided, the
 # directory specified will be used and not deleted at the end.
-# However, any 'src' subdirectory found there will be deleted to
-# ensure a clean copy of coredns is used. This allows for quicker
-# iteration as the entire contents of the go pkg directory don't
-# have to be downloaded each time.
 
 # The resulting coredns binary will be copied to the coredns-mdns
 # repo root.
@@ -21,8 +17,6 @@ export GOPATH="${1:-$(mktemp -d)}"
 if [ -z "${1:-}" ]
 then
     trap "chmod -R u+w $GOPATH; rm -rf $GOPATH" EXIT
-else
-    rm -rf "$GOPATH/src"
 fi
 mkdir -p $GOPATH/src/github.com/coredns
 source_dir=$(readlink -f "$(dirname "$0")/..")
@@ -30,10 +24,14 @@ source_dir=$(readlink -f "$(dirname "$0")/..")
 export COREDNS_REPO="${COREDNS_REPO:-https://github.com/openshift/coredns}"
 export COREDNS_BRANCH="${COREDNS_BRANCH:-master}"
 cd $GOPATH/src/github.com/coredns
-git clone ${COREDNS_REPO}
+if [ ! -d coredns ]
+then
+    git clone ${COREDNS_REPO}
+fi
 cd coredns
 git checkout ${COREDNS_BRANCH}
 # Make coredns use our local source
-echo "replace github.com/openshift/coredns-mdns => $source_dir" >> "$GOPATH/src/github.com/coredns/coredns/go.mod"
+rm vendor/github.com/openshift/coredns-mdns/*
+cp $source_dir/*.go vendor/github.com/openshift/coredns-mdns
 GO111MODULE=on GOFLAGS=-mod=vendor go build -o coredns .
 cp coredns "$source_dir"

--- a/mdns.go
+++ b/mdns.go
@@ -155,11 +155,8 @@ func (m *MDNS) BrowseMDNS() {
 			localEntry := *entry
 			log.Debugf("SRV Instance: %s, Service: %s, Domain: %s, HostName: %s, AddrIPv4: %s, AddrIPv6: %s\n", localEntry.Instance, localEntry.Service, localEntry.Domain, localEntry.HostName, localEntry.AddrIPv4, localEntry.AddrIPv6)
 			if strings.Contains(localEntry.Instance, m.filter) {
-				hostCustomDomain := m.ReplaceLocal(localEntry.HostName)
+				localEntry.HostName = m.ReplaceLocal(localEntry.HostName)
 				srvName := localEntry.Service + "." + m.Domain + "."
-				cname := "etcd-" + GetIndex(localEntry.HostName) + "." + m.Domain + "."
-				localEntry.HostName = cname
-				cnames[cname] = hostCustomDomain
 				srvHosts[srvName] = append(srvHosts[srvName], &localEntry)
 			} else {
 				log.Debugf("Ignoring entry '%s' because it doesn't match filter '%s'\n",


### PR DESCRIPTION
We need to use the SRV record unmodified if we're going to point it at the master hostnames directly.