### PR TITLE
Change mdnsHosts logging to info level

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -198,7 +198,7 @@ func (m *MDNS) BrowseMDNS() {
 	for k, v := range cnames {
 		(*m.cnames)[k] = v
 	}
-	log.Debugf("mdnsHosts: %v", m.mdnsHosts)
+	log.Infof("mdnsHosts: %v", m.mdnsHosts)
 	for name, entry := range *m.mdnsHosts {
 		log.Debugf("%s: %v", name, entry)
 	}


### PR DESCRIPTION
By default, the mdns plugin logs nothing to indicate whether it is
working or what records it is finding. Making the mdnsHosts log info
level will allow easy access to see what hosts are available without
logging an excessive amount (this log will happen at most once every
five seconds).