### PR TITLE
Extend mdns browse interval to 60 seconds

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -72,8 +72,6 @@ func setup(c *caddy.Controller) error {
 func browseLoop(m *MDNS) {
 	for {
 		m.BrowseMDNS()
-		// 5 seconds seems to be the minimum ttl that the cache plugin will allow
-		// Since each browse operation takes around 2 seconds, this should be fine
-		time.Sleep(5 * time.Second)
+		time.Sleep(60 * time.Second)
 	}
 }


### PR DESCRIPTION
Now that DNS bootstrapping is no longer dependent on the records
provided by mdns, we don't need to be browsing as often as we were.
This will reduce the amount of mdns traffic, which should help
scaling in larger environments.