### PR TITLE
Fix .gitignore for coredns binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 tags
-./coredns
+/coredns


### PR DESCRIPTION
When I fixed .gitignore for the coredns vendor, I also made it stop
ignoring the coredns binary that results from build-coredns. This
form should work for both.