### PR TITLE
Remove SRV and CNAME record support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,15 @@ baremetal-test-extra-1.example.com. 60 IN A   12.0.0.24
 baremetal-test-extra-1.example.com. 60 IN AAAA fe80::f816:3eff:fe49:19b3
 ~~~
 
-If `minimum SRV records` is specified in the configuration, the plugin will wait
-until it has at least that many SRV records before responding with any of them.
-`minimum SRV records` defaults to `3`.
+The `minimum SRV records` parameter was only used by a removed feature. It
+has no effect, but for backward compatibility it must be present to use any
+subsequent parameters.
 
 ~~~ corefile
 example.com {
-    mdns example.com 2
+    mdns example.com 0
 }
 ~~~
-
-This would mean that at least two SRV records of a given type would need to be
-present for any SRV records to be returned. If only one record is found, any
-requests for that type of SRV record would receive no results.
 
 If `filter text` is specified in the configuration, the plugin will ignore any
 mDNS records that do not include the specified text in the service name. This
@@ -63,7 +59,7 @@ set, all records will be processed.
 
 ~~~ corefile
 example.com {
-    mdns example.com 3 my-id
+    mdns example.com 0 my-id
 }
 ~~~
 
@@ -77,7 +73,7 @@ without setting a filter, set `filter text` to "".
 
 ~~~ corefile
 example.com {
-    mdns example.com 3 "" 192.168.1.1
+    mdns example.com 0 "" 192.168.1.1
 }
 ~~~
 

--- a/hack/build-coredns.sh
+++ b/hack/build-coredns.sh
@@ -16,6 +16,8 @@ set -ex -o pipefail
 CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
 
 export GOPATH="${1:-$(mktemp -d)}"
+# Must be an absolute path
+GOPATH=$(readlink -f "$GOPATH")
 if [ -z "${1:-}" ]
 then
     trap "chmod -R u+w $GOPATH; rm -rf $GOPATH" EXIT

--- a/mdns_test.go
+++ b/mdns_test.go
@@ -49,10 +49,8 @@ func TestAddARecord(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		hosts := tc.hosts
-		srvHosts := make(map[string][]*zeroconf.ServiceEntry)
-		cnames := make(map[string]string)
 		mutex := sync.RWMutex{}
-		m := MDNS{nil, tc.domain, 0, "", "", &mutex, &hosts, &srvHosts, &cnames}
+		m := MDNS{nil, tc.domain, "", "", &mutex, &hosts}
 		msg := new(dns.Msg)
 		reply := new(dns.Msg)
 		msg.SetReply(reply)
@@ -168,10 +166,8 @@ func TestReplaceDomain(t *testing.T) {
 	}
 
 	mdnsHosts := make(map[string]*zeroconf.ServiceEntry)
-	srvHosts := make(map[string][]*zeroconf.ServiceEntry)
-	cnames := make(map[string]string)
 	mutex := sync.RWMutex{}
-	m := MDNS{Domain: "testdomain", minSRV: 0, filter: "", bindAddress: "", mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts, cnames: &cnames}
+	m := MDNS{Domain: "testdomain", filter: "", bindAddress: "", mutex: &mutex, mdnsHosts: &mdnsHosts}
 	for _, tc := range testCases {
 		result := m.ReplaceDomain(tc.input)
 		if result != tc.expected {

--- a/setup.go
+++ b/setup.go
@@ -1,9 +1,6 @@
 package mdns
 
 import (
-	"errors"
-	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,18 +23,11 @@ func setup(c *caddy.Controller) error {
 	c.Next()
 	c.NextArg()
 	domain := c.Val()
-	minSRV := 3
 	// Note that a filter of "" will match everything
 	filter := ""
 	bindAddress := ""
-	if c.NextArg() {
-		val, err := strconv.Atoi(c.Val())
-		if err != nil {
-			text := fmt.Sprintf("Invalid minSRV: %s", err)
-			return plugin.Error("mdns", errors.New(text))
-		}
-		minSRV = val
-	}
+	// We now ignore the minSrv parameter
+	c.NextArg()
 	if c.NextArg() {
 		filter = c.Val()
 	}
@@ -51,10 +41,8 @@ func setup(c *caddy.Controller) error {
 	// Because the plugin interface uses a value receiver, we need to make these
 	// pointers so all copies of the plugin point at the same maps.
 	mdnsHosts := make(map[string]*zeroconf.ServiceEntry)
-	srvHosts := make(map[string][]*zeroconf.ServiceEntry)
-	cnames := make(map[string]string)
 	mutex := sync.RWMutex{}
-	m := MDNS{Domain: strings.TrimSuffix(domain, "."), minSRV: minSRV, filter: filter, bindAddress: bindAddress, mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts, cnames: &cnames}
+	m := MDNS{Domain: strings.TrimSuffix(domain, "."), filter: filter, bindAddress: bindAddress, mutex: &mutex, mdnsHosts: &mdnsHosts}
 
 	c.OnStartup(func() error {
 		go browseLoop(&m)


### PR DESCRIPTION
These were always very openshift-specific, and we no longer use them.
It simplifies the code quite a bit if we get rid of both these
record types.
    
The parameter is left to avoid breaking existing Corefiles. It has
no effect other than as a placeholder.